### PR TITLE
Potential fix for code scanning alert no. 12: Implicitly exported Android component

### DIFF
--- a/plugin-examples/plugintemplate/app/src/main/AndroidManifest.xml
+++ b/plugin-examples/plugintemplate/app/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
             plugin discovery  android devices.  If this is removed, the plugin will 
             not be able to be discovered or loaded.  -->
        <activity android:name="com.atakmap.app.component"
+           android:exported="false"
            tools:ignore="MissingClass">
            <intent-filter android:label="@string/app_name">
               <action android:name="com.atakmap.app.component" />


### PR DESCRIPTION
Potential fix for [https://github.com/DarthRaven1/AndroidTacticalAssaultKit-CIV/security/code-scanning/12](https://github.com/DarthRaven1/AndroidTacticalAssaultKit-CIV/security/code-scanning/12)

To fix the problem, we need to explicitly set the `android:exported` attribute for the `<activity>` element in the AndroidManifest.xml file. This will ensure that the component is not implicitly exported and will prevent unauthorized access. 

The best way to fix this without changing existing functionality is to add `android:exported="false"` to the `<activity>` element. This change should be made in the file `plugin-examples/plugintemplate/app/src/main/AndroidManifest.xml` on line 20.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
